### PR TITLE
Add Claude Code skills for blog workflow: raw capture, post drafting, ebook compilation

### DIFF
--- a/.claude/skills/ebook-forge/SKILL.md
+++ b/.claude/skills/ebook-forge/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: ebook-forge
+description: Compiles a themed cluster of this blog's published posts (from _posts/) — and optionally not-yet-written material from raw/ — into a coherent ebook manuscript, complete with a real table of contents, an author's-voice preface, and connective tissue between chapters, rather than just concatenating posts back to back. Use this when the user wants to turn a series of blog posts into a book/ebook, asks for a "manuscript", wants to compile posts on a theme (e.g. "the Principal-engineer bash series", "all my AI/agent posts") into one document, or asks how their blog output could become a book. Do NOT use this for writing a single new post from raw notes — that's the raw-to-post skill.
+---
+
+# Ebook Forge: posts → manuscript
+
+## Why a straight concatenation doesn't work
+
+Every post in `_posts/` is written to stand alone — each one re-establishes
+context, re-introduces the author's recurring frameworks, and ends with its
+own action items and teaser. Stapled together unedited, a "book" made of
+posts reads as repetitive and un-booklike: the same throat-clearing five
+times, no sense of a larger argument accumulating. The actual work of this
+skill is building the connective tissue and cutting the redundancy — the
+individual chapters (the posts) are already good; assembling them is a real
+editorial job, not a file-concatenation job.
+
+Read `raw-to-post/references/voice-profile.md` for the author's voice DNA —
+the preface and connective material need to sound like the same person, not
+like a table of contents generator.
+
+## Pipeline
+
+### 1. Scope the theme with the user
+
+Ask (if not already clear): what's the theme, and roughly what's the
+audience/promise of this book? "A collection of my posts" is too broad to
+edit well — "a book that takes a senior engineer from writing scripts that
+work to writing scripts that survive on-call" is a real spine to build a TOC
+around.
+
+### 2. Gather candidates
+
+Search by tag/category/keyword, e.g.:
+```bash
+grep -rl "<tag-or-keyword>" _posts/**/*.md
+```
+Read each candidate's full text, not just the title — confirm it actually
+fits the theme and check its "反直觉的洞察" (the one counter-intuitive claim
+each post commits to, per the humanity checklist) so you can sequence
+chapters by argument, not just by publish date.
+
+Also ask the user whether any `raw/` notes that never became posts should be
+folded in as a chapter — sometimes the rawest, most in-progress thinking
+is exactly what belongs in a book's final chapter or appendix ("where I'm
+still stuck").
+
+### 3. Design the arc, not just the order
+
+Propose a chapter order to the user before writing connective text. Options
+worth considering: chronological (shows how the author's thinking evolved —
+honest, but not always the strongest read), difficulty-ascending (Senior →
+Principal, mirrors this author's own recurring framing), or
+problem-clustered (group by the kind of failure mode, e.g. "hidden state",
+"declarative vs imperative", "default values"). Get the user's sign-off on
+the arc before drafting — restructuring after full connective text is
+written is expensive.
+
+### 4. Write the connective tissue
+
+- **Preface**: in the author's voice (see voice-profile.md), a few
+  paragraphs on why this cluster of posts belongs together and what the
+  reader will be able to do differently by the end. Draw on the author's
+  known facts (~20 years in the industry, mentoring background) rather than
+  inventing new biography.
+- **Chapter transitions**: a short paragraph before each chapter (2-5
+  sentences) bridging from the previous chapter's ending to this one's
+  opening — reuse the previous chapter's synthesis table/teaser as the
+  hook instead of writing a fresh generic intro.
+- **Deduplication**: when two posts both re-explain the same background
+  concept (e.g. two posts both re-derive what `kubectl wait` is), keep the
+  fullest explanation once — in the chapter where it's most load-bearing —
+  and replace the repeat in later chapters with a one-line callback
+  ("as chapter 2 covered, ..."). Flag any cut to the user rather than
+  silently dropping content that might have been load-bearing for that
+  specific post's argument.
+- **A closing chapter or afterword** that ties the individual chapter
+  aphorisms together into the book's single larger claim — this is the
+  same synthesis move each individual post makes at its own ending, one
+  level up.
+
+### 5. Assemble the manuscript
+
+Write to `ebooks/<book-slug>/manuscript.md` (create the directory; this is
+new to the repo, separate from `_posts/` since it's not meant to be served
+as web pages directly). Structure:
+
+```markdown
+# <Book title>
+
+## Preface
+...
+
+## Table of Contents
+1. <Chapter title> — from `_posts/.../slug.md`
+2. ...
+
+## Chapter 1: <title>
+<transition paragraph>
+<chapter body, lightly re-edited from the source post: strip frontmatter,
+adjust any "in this post" phrasing to "in this chapter", cut the
+duplicated background per step 4>
+
+## Chapter 2: <title>
+...
+
+## Afterword
+...
+```
+
+Keep a comment at the top of the manuscript noting the source post file for
+each chapter, so future edits to the original posts can be reconciled back
+into the book.
+
+### 6. Offer export
+
+This repo already has `docx` and `pdf` skills available for turning a
+finished markdown manuscript into a distributable file — offer to hand the
+assembled manuscript to one of those once the user confirms the content and
+arc are right. Don't run the export until the user has actually reviewed the
+manuscript; assembling wrong connective tissue is cheap to redo in markdown,
+expensive to redo after a full docx/pdf pass.
+
+### 7. Bilingual books
+
+If the source posts are bilingual pairs, ask whether the user wants one
+manuscript per language or a single bilingual edition — don't assume; the
+right call depends on the intended audience/publishing channel, which only
+the user knows.

--- a/.claude/skills/raw-capture/SKILL.md
+++ b/.claude/skills/raw-capture/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: raw-capture
+description: Captures a fast, low-friction note into raw/ when the user has a half-formed idea, a realization from a debugging session, or a brain dump they want saved before it evaporates — without expanding it into a full blog post yet. Use this when the user says things like "记一下这个想法", "add this to raw", "capture this before I forget", "笔记一下", or dumps a stream-of-consciousness technical insight and just wants it saved, not published. Do NOT use this for turning a raw note into an actual blog post — that's the raw-to-post skill's job.
+---
+
+# Raw Capture
+
+## Why this is a separate skill from raw-to-post
+
+输出倒逼输入 only works if both ends of the loop are cheap. If capturing an
+idea takes as much effort as writing the finished post, ideas stop getting
+captured at all, and the `raw/` well runs dry. This skill's only job is to
+get a real idea onto disk, in the author's own compressed shorthand, as fast
+as possible — polish and structure happen later, in `raw-to-post`.
+
+## What to preserve vs. what to clean up
+
+Look at the existing files in `raw/` before writing a new one — they range
+from tightly structured (`claude_inside.md` uses the author's own 根-干-枝-叶
+— root/trunk/branch/leaf — framework) to a three-line fragment
+(`stdout_vs_stderr.md`). Both are valid. Your job:
+
+- **Preserve**: the user's own phrasing, their shorthand terms, any
+  half-finished thought marked as unresolved. Don't smooth this into
+  finished prose — that's premature and it's not your call to make the
+  content sound more confident than the user actually is right now.
+- **Clean up**: only mechanical things — fix garbled dictation/OCR-style
+  artifacts, deduplicate an accidentally-repeated line, add markdown
+  structure (headers, lists) if the note is long enough to need
+  navigation. When unsure whether something is signal or noise, ask rather
+  than deleting silently.
+- **Never add**: content the user didn't say. If you see an interesting
+  angle while capturing, you can mention it back to the user as a question,
+  but don't fold your own elaboration into their raw note as if they'd said
+  it.
+
+## The one thing to always add: a gap marker
+
+Before finishing, ask (briefly, don't force a long reflection if the user's
+in a hurry): *"What's the part of this you couldn't yet explain simply to
+someone else?"* Add their answer as a short marked line at the end of the
+file, e.g.:
+
+```markdown
+> 待验证 / 未想清楚：<their answer, verbatim or lightly cleaned up>
+```
+
+This is the actual mechanism of 输出倒逼输入 on the input side — the gap is
+what makes the eventual post worth writing, and it's what `raw-to-post`
+should look for first when it's time to distill this note. If the user says
+there's no gap, that's fine — not every note needs one, but always ask once.
+
+## Mechanics
+
+- File: `raw/<topic-slug>.md`, lowercase, kebab-case, matching the existing
+  naming style (`langgraph_astream_explained.md` uses underscores — either
+  underscore or hyphen is fine, match whichever the user already leans
+  toward, don't mix within one filename).
+- No frontmatter needed — `raw/` files aren't Jekyll content, they're just
+  the author's working notes.
+- If a file on the same topic already exists, append to it (with a
+  timestamped or clearly separated section) rather than creating a
+  near-duplicate file — check `ls raw/` and grep for the topic first.
+- Do not touch `_posts/` from this skill. Capture is one-way into `raw/`;
+  promoting something to a published post is a distinct, deliberate step the
+  user asks for separately (via `raw-to-post`).

--- a/.claude/skills/raw-to-post/SKILL.md
+++ b/.claude/skills/raw-to-post/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: raw-to-post
+description: Turns a raw idea/notes file from raw/ (or a rough idea the user just typed out) into a publish-ready bilingual (Chinese + English) technical blog post for this Jekyll site (todzhang.com), matching the blog's established house voice — narrative hook, chapter structure with tables and mental-model callouts, philosophy-quote framing, and an action-items/teaser ending. Use this whenever the user wants to draft, write up, turn into a post, distill, or publish a blog entry from something in raw/, wants to convert notes/ideas/a brain dump into a blog post for this repo, or asks "help me write this up" / "把这个写成博客" about a technical or personal-growth topic. Also use it when the user wants feedback on whether a draft post sounds like them or sounds like generic AI writing.
+---
+
+# Raw → Post: distilling ideas into this blog's voice
+
+## Why this exists
+
+The user's theory of learning here is 输出倒逼输入 — writing forces real
+understanding, and it also builds their name in the industry. Both goals die
+if the output reads like generic AI-blog filler. Your job is not "write a
+blog post about X" — it's "help this specific author turn their own raw
+thinking into the sharpest, most recognizably-theirs version of that
+thinking, in the exact shape their readers already expect from them."
+
+Read `references/voice-profile.md` in full before drafting anything — it's
+the distilled house style, extracted from real published posts, not a
+generic "how to write a tech blog" guide. Read `references/humanity-checklist.md`
+before calling any draft finished — it's the gate that keeps output from
+drifting into AI sameness.
+
+## Pipeline
+
+### 1. Find and read the source material
+
+- If the user points at a `raw/*.md` file, read it in full. These files are
+  dense, compressed personal notes (often using the author's own shorthand
+  frameworks like 根干枝叶, 第一性原理, 五个为什么) — they are the real
+  intellectual content, just not yet shaped into prose. Don't treat them as
+  a rough draft to lightly edit; treat them as ore to smelt.
+- If the user just typed an idea inline with no raw file, that's fine too —
+  treat their message as the raw material, and consider offering to save a
+  distilled version back into `raw/` first (see the `raw-capture` skill) so
+  the knowledge base grows even if this particular idea doesn't become a
+  post today.
+- Skim 2-3 *existing* posts close to this topic (`grep -rl <keyword>
+  _posts/`) so you don't repeat an argument the author has already made, and
+  so you can cross-link or explicitly build on a previous post if relevant.
+
+### 2. Find the spine
+
+Before writing a single line of the post, identify out loud (to the user,
+briefly) what you think:
+
+- **The one counter-intuitive claim** the post is actually making. If the
+  raw notes contain several, ask the user which one is the spine — a post
+  that tries to carry three equally-weighted insights usually ends up
+  saying none of them memorably.
+- **What kind of hook fits**: a real incident the user can confirm happened,
+  a first-person confession, or a more essayistic/philosophical opener (see
+  `tianren-wushuai-philosophy` for the non-incident-driven mode). Don't
+  default to "Alex" reflexively — check `humanity-checklist.md`'s interview
+  questions first.
+- **tech vs life category** — most posts are `tech`; use `life` when the
+  core content is career/philosophy/personal-growth rather than a technical
+  mechanism.
+
+### 3. Run the required interview
+
+Per `humanity-checklist.md`, ask the user the few sharp questions about real
+details, real opinions, and real anecdotes *before* drafting the hook. This
+is the step most likely to get skipped under time pressure — don't skip it.
+It's fine to batch these into one short message.
+
+### 4. Draft the Chinese version first
+
+Chinese is this blog's primary voice — the English version is an adaptation,
+not the source. Follow the structural skeleton in `voice-profile.md`:
+frontmatter → opening quote → hook → reader-value preview → chapters (code
+anchors, tables, one named mental model each, a one-line chapter closer) →
+synthesis → action items → teaser → closing aphorism.
+
+Concretely:
+- Pick a real, attributable opening quote (ask the user if unsure, or
+  propose 2-3 candidates that fit the spine).
+- Write the hook using only real or user-confirmed details.
+- For every comparison (bug vs. fix, default vs. override, before vs.
+  after), reach for a table before reaching for prose — that's this
+  author's default move, not decoration.
+- Pull at most 1-2 terms from the vocabulary bank in `voice-profile.md` per
+  post. Repeating the same framework in every post is the fastest way to
+  make this voice start sounding like a template.
+- End with "立刻可以做的事" (concrete, tied to the reader's own repo/team —
+  not generic advice) and a "预告" only if there's a genuine next post in
+  mind; ask the user rather than inventing a series commitment they didn't
+  make.
+
+### 5. Adapt (don't translate) the English version
+
+Re-derive the hook and idiom for an English-reading audience while keeping
+the same argument, code, and tables. A phone call at "凌晨两点" and one at
+"11pm" carry different connotations in each culture — pick what lands, don't
+transliterate. Confirm both versions reach the same stance in the synthesis
+section.
+
+### 6. Mechanics — file placement and frontmatter
+
+Follow `voice-profile.md`'s "Mechanics" section exactly:
+- `_posts/YYYY/MM/DD/YYYY-MM-DD-<slug>-zh.md` and `...-en.md` (create the
+  date directories if they don't exist).
+- Frontmatter fields in the documented order and format, `permalink:
+  /blogs/<category>/<lang>/<slug>` with `zh`/`en` (never `cn`).
+- Pick `header.image` from existing files under `assets/images/` — search
+  first (`ls assets/images | grep -i <keyword>`, and check the `hd_*`
+  library), never invent a new image file.
+- Pick tags from the existing tag vocabulary where reasonable
+  (`grep -rh '  - ' _posts | sort | uniq -c | sort -rn` to check), 3-5 tags.
+
+### 7. Run the humanity checklist before presenting the draft
+
+Walk through every item in `references/humanity-checklist.md`'s "What every
+draft must have" and "Phrases and moves to never use" sections explicitly.
+Fix anything that fails rather than presenting a draft you know is weak on
+one of these axes. If something can't be fixed without more input from the
+user (a missing real anecdote, an unconfirmed number), say so plainly
+instead of quietly filling the gap with something invented.
+
+### 8. Hand back to the user
+
+Tell the user where the files were written, what's still a placeholder that
+needs a real detail from them, and ask whether they want it committed. Do
+not commit/push without being asked — publishing to a public blog is a
+visible action, treat it like one.
+
+## Reference files
+
+- `references/voice-profile.md` — the structural skeleton, the mental-model
+  vocabulary bank, recurring rhetorical devices, and the exact file/frontmatter
+  mechanics. Read this before drafting.
+- `references/humanity-checklist.md` — the anti-genericness gate and the
+  required-interview questions. Read this before drafting and again before
+  declaring a draft finished.

--- a/.claude/skills/raw-to-post/references/humanity-checklist.md
+++ b/.claude/skills/raw-to-post/references/humanity-checklist.md
@@ -1,0 +1,94 @@
+# Humanity Checklist
+
+The whole point of this pipeline is "输出倒逼输入" — writing forces real
+learning, and the writing has to actually be *the author's*, not a generic
+LLM essay wearing the author's frontmatter. This file is the gate a draft has
+to pass before it's offered to the user as done.
+
+## Why this file exists
+
+Left alone, a model asked to "write a technical blog post about X" converges
+on the same handful of moves regardless of who's asking: hedge everything,
+summarize instead of arguing, praise every technology's tradeoffs equally,
+reach for the same dozen transition phrases. None of that is *wrong*, but a
+few hundred of these posts across the internet read identically. This
+author's blog already has a real, distinctive voice (see `voice-profile.md`)
+— the job here is to protect it, not sand it down toward the mean.
+
+## Phrases and moves to never use
+
+If any of these show up in a draft, rewrite the sentence — don't just
+delete the phrase, since the underlying move (hedge, pad, summarize) is the
+actual problem:
+
+- "In today's fast-paced world / rapidly evolving landscape"
+- "It's important to note that...", "It's worth mentioning..."
+- "Dive into", "unlock the power of", "game-changer", "seamless(ly)"
+- "In conclusion", "Overall", "To sum up" as a section opener
+- A closing paragraph that restates the intro without adding anything
+- On-one-hand/on-the-other-hand hedging that never actually lands on a
+  position — this author *always* lands on a position (see "Principal's
+  解法", "一句话哲学", "第一性原则" — these are all verdicts, not surveys)
+- A list of adjectives standing in for a real claim ("robust, scalable,
+  efficient solution") — replace with the specific mechanism that makes it
+  true, or cut it
+- Praising a tool/pattern without naming what it costs, or criticizing one
+  without naming what it's for — this voice's tables always show both sides
+- Uniform, evenly-spaced rhythm (same sentence length throughout, an em dash
+  in every third sentence) — read the draft aloud; if it sounds like a
+  metronome, vary it
+
+## What every draft must have (verify explicitly before calling it done)
+
+1. **A stance the reader could disagree with.** Not "there are tradeoffs" —
+   an actual claim like "用户态 polling 永远是次优解" that someone could push
+   back on in a comment. If the raw material doesn't contain one, that's a
+   sign the piece isn't ready to publish yet — surface this to the user
+   rather than manufacturing a fake-confident claim to fill the gap.
+2. **At least one concrete, checkable artifact**: a real error message, a
+   real log line, a real file path, a real command output — pulled from the
+   raw notes or supplied by the user. Never invent a plausible-looking error
+   message or benchmark number; mark it `[NEEDS REAL ARTIFACT: ...]` and ask
+   instead.
+3. **Exactly one clearly-stated counter-intuitive insight** (a "反直觉的洞察"),
+   not a laundry list of five equally-weighted takeaways. Pick the strongest
+   one from the raw notes.
+4. **A biographical or narrative detail that only the author could supply**
+   if the post uses a personal hook (a real mentee's situation, a real
+   incident, a real year/company/scale number). If the raw notes don't have
+   one, do not invent an "Alex" scenario from nothing — ask the user for the
+   real anecdote, or fall back to a first-person framing that doesn't
+   require a fabricated third party. See "Required interview" below.
+5. **Variation from the last few posts.** Before finalizing, skim the 2-3
+   most recent posts in `_posts/` (`ls -t _posts/*/*/*/*.md | head`) and
+   check: same narrative device (Alex) three times running? Same closer
+   label ("一句话哲学") every time? Same mental-model term reused back to
+   back? If yes, change it — the goal is a recognizable voice, not a
+   template.
+
+## Required interview before drafting (don't skip this)
+
+Never fabricate specifics attributed to the real author. Before writing the
+narrative hook, ask the user directly (a short, specific question, not an
+open-ended "tell me about yourself"):
+
+- "Did this actually happen to you, or should I frame it in third person /
+  hypothetically?"
+- "Is there a real number, error message, or timestamp from when this
+  happened that I should use instead of a generic one?"
+- "Is there a strong opinion you hold here that I should make the spine of
+  the post, even if it's a little combative?"
+
+If the user is in a hurry and says "just use your judgment / make something
+up that's plausible", that's their call to make — but say explicitly in
+your reply which details are invented placeholders, so they can swap in real
+ones before publishing. Never silently present a fabricated anecdote as if
+it were the author's real experience.
+
+## Bilingual check
+
+The English version must not be a literal translation — re-derive the hook,
+since a "凌晨两点" phone call reads differently translated than reframed for
+an English-reading audience. Keep the same argument, tables, and code; the
+narrative dressing can and should shift idiom. Cross-check both versions
+land the same core stance.

--- a/.claude/skills/raw-to-post/references/voice-profile.md
+++ b/.claude/skills/raw-to-post/references/voice-profile.md
@@ -1,0 +1,165 @@
+# Voice Profile — Highly Distinguish / todzhang.com
+
+Extracted by reading the actual published posts in `_posts/`, not invented. Every
+pattern below was pulled from at least two real posts (mainly the 2026 batch,
+which is the most mature form of the voice — `every-sleep-is-a-lie`,
+`cognitive-scaffolding-ai-memory-skills`, `tianren-wushuai-philosophy`,
+`minikube-windows-path-pitfall`). When in doubt, go re-read one of those rather
+than trust this summary blindly — this doc will drift out of date faster than
+the posts do.
+
+## Known author facts (already public — reuse, don't re-invent)
+
+- ~20 years in the industry ("我入行二十年", stated in `every-sleep-is-a-lie-zh`).
+- Writes/reviews production code and does code review / mentoring for other
+  engineers (the "Alex" stories are framed as real mentoring sessions).
+- Comfortable in bash, Kubernetes, Terraform, Airflow, Spark, dbt, LLM
+  internals (Claude/LangChain/LangGraph) — the raw/ folder is the reliable
+  source of truth for what topics are real expertise vs. speculation.
+- Draws as easily on Chinese classical philosophy (王阳明, 孟子的"知人论世",
+  庄子/道家的"天人五衰") as on Western sources (Steve Jobs, Thomas Reid, SRE
+  folklore) and CS theory (Parnas information hiding, Occam's razor, the free
+  energy principle). This cross-domain mixing is a core signature — do not
+  flatten it into "just tech quotes."
+
+If a draft needs a biographical claim not listed here (a company name, a
+specific year, a specific incident), **do not invent it** — ask the user, or
+leave a clearly marked placeholder (see `humanity-checklist.md`).
+
+## The structural skeleton
+
+Not every post uses every element, and that's correct — forcing all of them
+into every post is exactly the kind of formulaic sameness to avoid. Treat this
+as the toolbox this author reaches into, not a template to fill in
+mechanically.
+
+1. **Frontmatter** (see Mechanics below).
+2. **Opening quote** — a real, attributable quote, one line, from a source
+   *outside* the immediate tech topic when possible (philosophy, history, a
+   craft maxim). This is the single most consistent element across every era
+   of this blog (present even in 2016-era posts).
+3. **Title (H1)** — often more vivid/provocative than the frontmatter
+   `title:`, sometimes identical. Chinese titles lean toward a concrete
+   image + stakes ("你脚本里的每一个 sleep 都在说谎", "花冠不败是幻觉，山静日长是出路").
+4. **Optional italic subtitle promise** — one line, `*From X to Y — what
+   separates senior from principal*` style. Names the transformation the
+   reader will undergo, not just the topic.
+5. **The hook** — a concrete, specific, real-feeling scene: a named person
+   (often "Alex", but vary this — a first-person confession or an
+   unembellished incident description work just as well and should be used
+   sometimes instead), a timestamp ("凌晨两点", "11pm"), a real artifact (an
+   error message, a diff, a log line). Ground it in sensory/situational
+   specifics, never "imagine a developer who...".
+6. **Reader-value preview** — a short bullet list of 2-3 things the reader
+   will walk away with, each phrased as an intuition, not a topic
+   ("`sleep` 是说谎的注释，`kubectl wait` 是会执行的注释" — not "we'll cover
+   kubectl wait").
+7. **An explicit ordering note** — pedagogical order (most useful first) is
+   called out as different from chronological/discovery order. A small but
+   recurring signal of intentional teaching design.
+8. **Numbered chapters**, each roughly:
+   - A concrete code/config/error anchor — real syntax, not pseudocode.
+   - Sometimes a "普通人的看法 / 资深工程师的洞察" (naive take vs. seasoned
+     take) contrast — use when there's a genuine gap in understanding to
+     expose, skip it when the chapter doesn't have one.
+   - A table contrasting symptoms/anti-patterns/defaults against fixes —
+     tables are a heavy signature of this voice, used for anything
+     comparable (bug vs cause, tool vs hidden state, before vs after).
+   - A named mental-model callout — pick from the vocabulary bank below,
+     don't reuse the same one twice in one post unless it's the post's
+     explicit throughline.
+   - A one-line, boxed/quoted "chapter philosophy" — an aphorism that
+     could stand alone outside the post. Vary the label wording
+     ("一句话哲学", "直觉口诀", "第一性原则", or no label, just a blockquote) —
+     don't let this become a mechanical `## 一句话哲学` heading every single
+     time.
+9. **Ending**:
+   - A synthesis table or diagram pulling the chapters' threads together
+     under one abstraction (e.g. "三张地图").
+   - **"立刻可以做的事"** — a short numbered list of concrete actions the
+     reader can do *today*, tied to their own codebase/team, not generic
+     advice.
+   - **"预告"** — a teaser for the next post, ideally a real thing the
+     author intends to write, creating series continuity. Don't invent a
+     teaser that won't be followed up — check with the user.
+   - A closing italicized aphorism, original (not the opening quote
+     repeated), that reframes the whole post in one sentence.
+
+## Vocabulary bank — the author's mental-model toolbox
+
+These terms recur across `raw/` notes and published posts. They are the
+author's actual intellectual signature, distilled from real thinking habits —
+not tech-blog decoration. Reach for the one that's *true* for the insight at
+hand; don't sprinkle them for flavor.
+
+| Term | What it's for |
+|---|---|
+| 第一性原理 (first principles) | Stripping a "everyone knows X" belief down to the actual mechanism underneath. |
+| 根-干-枝-叶 (root-trunk-branch-leaf) | The author's personal note-taking framework for going from a core question → mechanism → sub-topics → concrete facts. Visible in raw notes; rarely surfaces literally in finished posts, but its logic (root question first) shapes the hook + preview. |
+| 知人论世 (Mencius) | Understanding a decision requires knowing both the actor's context ("世") and their method ("事") — used for framing why a default/design choice makes sense given its era or constraints. |
+| 对称性破缺 (symmetry breaking) | Naming the specific asymmetry that turns a clean abstraction into a leaky one. |
+| 自由能原理 / 最小化惊讶 (free energy principle) | Framing a design as reducing surprise/uncertainty for the reader or the system, rather than adding raw capability. |
+| 奥卡姆剃刀 (Occam's razor) | Justifying why the simpler mechanism is the right explanation. |
+| 五个为什么 (5 whys) | Drilling from a symptom to a root cause, shown as a literal Q/A chain. |
+| Parnas information hiding | Justifying scoping/encapsulation choices (e.g. why an env var should only apply to one command, not the whole script). |
+| 信息单向性 (information directionality) — coined | Every context boundary (host↔guest, frontend↔backend, ORM↔SQL) rewrites information according to its own assumptions; semantics live in the human's head, syntax lives in the tool. |
+| 代码考古学 (code archaeology) — coined | The trap of "magic" fixes nobody remembers the reason for three months later. |
+| 部落知识 → 工程产物 | The Principal-vs-Senior dividing line: turning something only remembered by word of mouth into a documented/enforced artifact (a flag, a README line, a check). |
+
+Feel free to name a *new* framework if the raw material genuinely calls for
+one — this bank should grow, not fossilize.
+
+## Recurring rhetorical devices
+
+- Direct reader address at a pivot point: "如果你也遇到过类似 ... 下面这一节就是为你准备的。"
+- "面试拿分点" — flagging a detail as specifically interview-worthy, rewarding readers who want to level up, not just fix today's bug.
+- Seniority framing as a throughline: Senior vs Principal, "普通人" vs "资深工程师" — used to make the stakes about the reader's own growth, not just the bug.
+- Quotes and mental models pulled from *outside* the tech domain into a tech problem, and vice versa (Wang Yangming next to `kubectl wait`). This juxtaposition is a deliberate part of the voice, not a quirk to sand off.
+- Tables over prose whenever two or more things are being compared.
+- Real, runnable code blocks with realistic variable names (`WAIT_TIMEOUT`, `HOST_MOUNT_SRC`) — never `foo`/`bar` placeholders in the final fix.
+
+## Mechanics (file layout, frontmatter, naming)
+
+Confirmed by grepping every post under `_posts/`:
+
+- **Path**: `_posts/YYYY/MM/DD/YYYY-MM-DD-<slug>.md` (year/month/day are real
+  nested directories, matching `date:` in the frontmatter).
+- **Bilingual pair**: two files, same slug, language suffix on the *filename*:
+  `<slug>-zh.md` and `<slug>-en.md` (this is the current, consistent
+  convention as of the 2026 posts — older posts used a bare filename for one
+  language plus `_en` for the other, which is legacy and shouldn't be copied
+  for new posts). If the topic is inherently English-first (e.g. quoting
+  English source material throughout), it's fine to have only one file, but
+  default to producing both languages unless the user says otherwise — the
+  point of this whole pipeline is reach across both audiences.
+- **Frontmatter fields**, in this order:
+  ```yaml
+  ---
+  title: <string, matches or slightly softer than the H1>
+  header:
+      image: /assets/images/<existing-file>.{png,jpg,jpeg}
+  date: YYYY-MM-DD
+  tags:
+   - lowercase-kebab-topics (3-5 of them)
+  permalink: /blogs/<category>/<lang>/<slug>
+  layout: single
+  category: tech   # or life, for personal/philosophical posts
+  ---
+  ```
+- **`category`**: `tech` for engineering content, `life` for
+  philosophy/career/personal-growth posts (rare, but the pattern exists —
+  `tianren-wushuai-philosophy`). It drives the first path segment of
+  `permalink`, so keep them consistent within a bilingual pair.
+- **`permalink` lang segment**: use `zh` and `en` (not `cn` — that's a legacy
+  value from older posts, don't propagate it into new ones).
+- **`header.image`**: reuse an existing file under `assets/images/` — do not
+  invent a new binary asset. Prefer files already prefixed `hd_` (a small
+  library of thematic illustrations already used across many posts) that
+  loosely match the topic; if nothing fits well, it's acceptable to reuse a
+  generic evocative image (this blog already reuses e.g. `swan.jpg` across
+  unrelated posts) rather than block the post on finding a perfect image.
+  List candidates with `ls assets/images | grep -i <keyword>` and
+  `ls assets/images | grep '^hd_'` before picking.
+- **Tags**: lowercase, kebab-case where multi-word, 3-5 per post, drawn from
+  what's actually used elsewhere (`grep -rh '  - ' _posts | sort | uniq -c |
+  sort -rn` to see the existing tag vocabulary before inventing new ones).

--- a/README.md
+++ b/README.md
@@ -15,3 +15,26 @@ Then download the blog source to clipboard
 ```shell
 cat ~/Downloads/docker-desktop-security-fix.md | pbcopy
 ```
+
+# AI-assisted workflow (raw idea → post → book)
+
+This repo also uses `raw/` as a scratchpad for half-formed ideas and
+`.claude/skills/` for Claude Code skills that turn that raw material into
+publish-ready output in this blog's own voice, without flattening it into
+generic AI writing:
+
+- **`raw-capture`** — quickly saves a new idea into `raw/` (low friction, no
+  polishing yet).
+- **`raw-to-post`** — distills a `raw/*.md` file (or a fresh idea) into a
+  bilingual (zh/en) blog post matching this blog's established structure,
+  tables, and recurring frameworks. Reads `raw-to-post/references/voice-profile.md`
+  and `humanity-checklist.md` to keep the output sounding like a specific
+  person, not an AI template — it will ask for real anecdotes/opinions
+  rather than inventing them.
+- **`ebook-forge`** — compiles a themed cluster of published posts (plus,
+  optionally, unpublished `raw/` material) into an ebook manuscript under
+  `ebooks/`, with real connective tissue between chapters instead of a
+  straight concatenation.
+
+Point Claude Code at a file in `raw/` and ask it to write the post — the
+skills trigger automatically.


### PR DESCRIPTION
## Summary

Introduces a structured AI-assisted workflow for managing this blog's content pipeline, from raw idea capture through published posts to ebook compilation. Adds three Claude Code skills and supporting reference documentation that enforce the blog's distinctive voice and prevent generic AI output.

## Key Changes

- **`.claude/skills/raw-capture/SKILL.md`** — New skill for low-friction capture of half-formed ideas into `raw/` without requiring full polish or structure. Emphasizes preserving the author's own phrasing and shorthand while adding a "gap marker" to identify what still needs clarification.

- **`.claude/skills/raw-to-post/SKILL.md`** — New skill that transforms raw notes or ideas into publish-ready bilingual (Chinese/English) blog posts. Includes a structured pipeline: source material review → spine identification → required interview → Chinese draft → English adaptation → mechanics/frontmatter → humanity checklist validation.

- **`.claude/skills/raw-to-post/references/voice-profile.md`** — Comprehensive reference extracted from actual published posts (not invented). Documents the author's structural patterns (opening quote, hook, reader-value preview, numbered chapters with tables and mental-model callouts, action items, teaser), recurring rhetorical devices, a vocabulary bank of intellectual frameworks (第一性原理, 知人论世, 对称性破缺, etc.), and exact file/frontmatter mechanics for Jekyll posts.

- **`.claude/skills/raw-to-post/references/humanity-checklist.md`** — Gate that prevents output from drifting into generic AI writing. Lists phrases/moves to never use, required elements every draft must have (a stance, concrete artifacts, one counter-intuitive insight, real biographical details), and a required pre-drafting interview to capture real anecdotes rather than inventing them.

- **`.claude/skills/ebook-forge/SKILL.md`** — New skill for compiling themed clusters of published posts into coherent ebook manuscripts. Handles scoping, candidate gathering, arc design, connective tissue writing, deduplication, and assembly into a structured manuscript with preface, chapter transitions, and afterword.

- **`README.md`** — Updated with a new section explaining the AI-assisted workflow and how the three skills fit together in the content pipeline.

## Notable Implementation Details

- The voice-profile reference is explicitly extracted from real 2026-era posts (`every-sleep-is-a-lie`, `cognitive-scaffolding-ai-memory-skills`, `tianren-wushuai-philosophy`, `minikube-windows-path-pitfall`) rather than being a generic template, with a note that readers should re-read actual posts if in doubt.

- The humanity checklist includes a specific "Required interview" section that prevents fabrication of biographical details — if the user is in a hurry and says "just make something up," the skill explicitly flags which details are invented placeholders so they can be swapped for real ones before publishing.

- The ebook-forge skill treats post concatenation as an editorial problem, not a file-concatenation problem — it deduplicates repeated background explanations, writes connective tissue between chapters, and builds a larger argument arc rather than just stapling posts together.

- All three skills are designed to be low-friction at their respective stages: raw capture is intentionally unpolished, raw-to-post includes a structured interview to gather real details upfront, and ebook-forge offers export to existing `docx`/`pdf` skills once the manuscript is approved.

https://claude.ai/code/session_01RPBhoRHQXiArrC7ixTttic